### PR TITLE
feat: implement robust WebSocket reconnection logic with exponential …

### DIFF
--- a/src/components/LiveStream.tsx
+++ b/src/components/LiveStream.tsx
@@ -12,6 +12,7 @@ interface LiveStreamProps {
 export function LiveStream({ isConnected }: LiveStreamProps) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [filter, setFilter] = useState<Record<string, string>>({});
   const [filterInput, setFilterInput] = useState('');
@@ -70,15 +71,31 @@ export function LiveStream({ isConnected }: LiveStreamProps) {
     const unsubLog = logStreamClient.on('log', handleLog);
     const unsubConnected = logStreamClient.on('connected', () => {
       console.log('Stream connected');
+      setIsStreaming(true);
+      setIsReconnecting(false);
     });
     const unsubDisconnected = logStreamClient.on('disconnected', () => {
       setIsStreaming(false);
+      setIsReconnecting(false);
+    });
+    const unsubReconnecting = logStreamClient.on('reconnecting', (msg) => {
+      console.log('Stream reconnecting:', msg.message);
+      setIsReconnecting(true);
+      setIsStreaming(true); // Keep UI showing stream controls but in reconnecting state
+    });
+    const unsubReconnected = logStreamClient.on('reconnected', () => {
+      console.log('Stream reconnected');
+      setIsStreaming(true);
+      setIsReconnecting(false);
+      toast.success('Connection successfully restored');
     });
 
     return () => {
       unsubLog();
       unsubConnected();
       unsubDisconnected();
+      unsubReconnecting();
+      unsubReconnected();
     };
   }, [handleLog]);
 
@@ -193,9 +210,9 @@ export function LiveStream({ isConnected }: LiveStreamProps) {
         <div className="flex items-center gap-4 text-sm">
           {isStreaming && (
             <div className="flex items-center gap-2">
-              <div className={`h-2 w-2 rounded-full ${isPaused ? 'bg-warning' : 'bg-success animate-pulse'}`} />
+              <div className={`h-2 w-2 rounded-full ${isReconnecting ? 'bg-warning animate-pulse' : isPaused ? 'bg-warning' : 'bg-success animate-pulse'}`} />
               <span className="text-muted-foreground font-mono">
-                {isPaused ? 'Paused' : 'Streaming'}
+                {isReconnecting ? 'Reconnecting...' : (isPaused ? 'Paused' : 'Streaming')}
               </span>
             </div>
           )}

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -127,7 +127,7 @@ function LogLine({ log, isExpanded, onToggle, delay }: LogLineProps) {
 
   return (
     <div
-      className={`${levelStyles[level]} cursor-pointer animate-log-appear`}
+      className={`${levelStyles[level]} group cursor-pointer animate-log-appear`}
       style={{ animationDelay: `${delay}ms` }}
       onClick={onToggle}
     >

--- a/src/lib/streamClient.ts
+++ b/src/lib/streamClient.ts
@@ -1,7 +1,7 @@
 import { BackendConfig } from '@/types/logs';
 
 export interface StreamMessage {
-  type: 'connected' | 'log' | 'filter_updated' | 'error' | 'reconnecting' | 'reconnected';
+  type: 'connected' | 'log' | 'filter_updated' | 'error' | 'reconnecting' | 'reconnected' | 'disconnected';
   data?: {
     id: string;
     timestamp: string;
@@ -22,6 +22,7 @@ export class LogStreamClient {
   private listeners: Map<string, Set<(msg: StreamMessage) => void>> = new Map();
   private config: BackendConfig | null = null;
   private filter: Record<string, string> = {};
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.listeners.set('log', new Set());
@@ -36,6 +37,10 @@ export class LogStreamClient {
     this.config = config;
     this.filter = filter;
     this.reconnectAttempts = 0;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.doConnect();
   }
 
@@ -91,7 +96,7 @@ export class LogStreamClient {
 
       this.ws.onclose = (event) => {
         console.log('[LogStream] Disconnected:', event.code, event.reason);
-        this.emit('disconnected', { type: 'disconnected' as any, message: 'Disconnected' });
+        this.emit('disconnected', { type: 'disconnected', message: 'Disconnected' });
         if (this.config) {
           this.attemptReconnect();
         }
@@ -124,7 +129,11 @@ export class LogStreamClient {
       attempt: this.reconnectAttempts
     });
 
-    setTimeout(() => {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
       if (this.config) {
         this.doConnect();
       }
@@ -144,6 +153,10 @@ export class LogStreamClient {
 
   disconnect(): void {
     this.config = null; // Set to null before closing to prevent reconnection
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.ws) {
       this.ws.close();
       this.ws = null;

--- a/src/lib/streamClient.ts
+++ b/src/lib/streamClient.ts
@@ -1,7 +1,7 @@
 import { BackendConfig } from '@/types/logs';
 
 export interface StreamMessage {
-  type: 'connected' | 'log' | 'filter_updated' | 'error';
+  type: 'connected' | 'log' | 'filter_updated' | 'error' | 'reconnecting' | 'reconnected';
   data?: {
     id: string;
     timestamp: string;
@@ -11,13 +11,14 @@ export interface StreamMessage {
   };
   message?: string;
   filter?: Record<string, string>;
+  attempt?: number;
 }
 
 export class LogStreamClient {
   private ws: WebSocket | null = null;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
-  private reconnectDelay = 1000;
+  private reconnectDelay = 2000;
   private listeners: Map<string, Set<(msg: StreamMessage) => void>> = new Map();
   private config: BackendConfig | null = null;
   private filter: Record<string, string> = {};
@@ -27,6 +28,8 @@ export class LogStreamClient {
     this.listeners.set('connected', new Set());
     this.listeners.set('disconnected', new Set());
     this.listeners.set('error', new Set());
+    this.listeners.set('reconnecting', new Set());
+    this.listeners.set('reconnected', new Set());
   }
 
   connect(config: BackendConfig, filter: Record<string, string> = {}): void {
@@ -61,8 +64,12 @@ export class LogStreamClient {
 
       this.ws.onopen = () => {
         console.log('[LogStream] Connected');
+        if (this.reconnectAttempts > 0) {
+          this.emit('reconnected', { type: 'reconnected', message: 'Connection restored' });
+        } else {
+          this.emit('connected', { type: 'connected', message: 'Connected to log stream' });
+        }
         this.reconnectAttempts = 0;
-        this.emit('connected', { type: 'connected', message: 'Connected to log stream' });
       };
 
       this.ws.onmessage = (event) => {
@@ -84,8 +91,10 @@ export class LogStreamClient {
 
       this.ws.onclose = (event) => {
         console.log('[LogStream] Disconnected:', event.code, event.reason);
-        this.emit('disconnected', { type: 'connected', message: 'Disconnected' });
-        this.attemptReconnect();
+        this.emit('disconnected', { type: 'disconnected' as any, message: 'Disconnected' });
+        if (this.config) {
+          this.attemptReconnect();
+        }
       };
 
       this.ws.onerror = (error) => {
@@ -101,12 +110,19 @@ export class LogStreamClient {
   private attemptReconnect(): void {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       console.log('[LogStream] Max reconnect attempts reached');
+      this.emit('error', { type: 'error', message: 'Max reconnect attempts reached. Please refresh.' });
       return;
     }
 
     this.reconnectAttempts++;
     const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
     console.log(`[LogStream] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+
+    this.emit('reconnecting', { 
+      type: 'reconnecting', 
+      message: `Reconnecting in ${delay / 1000}s...`,
+      attempt: this.reconnectAttempts
+    });
 
     setTimeout(() => {
       if (this.config) {
@@ -127,11 +143,11 @@ export class LogStreamClient {
   }
 
   disconnect(): void {
+    this.config = null; // Set to null before closing to prevent reconnection
     if (this.ws) {
       this.ws.close();
       this.ws = null;
     }
-    this.config = null;
   }
 
   on(event: string, callback: (msg: StreamMessage) => void): () => void {


### PR DESCRIPTION
## 🚀 Implemented WebSocket Reconnection with Exponential Backoff (fixes #27)

### 📝 What I Did:
Hey maintainers! I worked on resolving **Issue #27** to fix the WebSocket stream connection dropping whenever the backend restarts or if there is a temporary network glitch. 

Previously, if the connection dropped, the UI would just stay disconnected until the user manually refreshed the page. To fix this, I implemented an **Exponential Backoff** reconnection strategy so the client attempts to reconnect automatically with increasing delays, and added a nice visual "Reconnecting..." state to the UI to keep the user informed!

---

### 🛠️ Key Changes:

#### 1. Reconnection Logic (`src/lib/streamClient.ts`)
- **Exponential Backoff**: Changed the retry interval to start at a base of `2000ms` (2 seconds) and double with each subsequent retry (`2s`, `4s`, `8s`, `16s`...). I used the formula: `2000 * Math.pow(2, attempts - 1)`. This prevents the client from hammering the server during downtime.
- **New Event Emitters**: Added `'reconnecting'` and `'reconnected'` states so the client can notify the UI about the current connection status.
- **Auto-Reconnect Loop Fix**: Fixed a bug where calling the manual `disconnect()` function would accidentally trigger a new reconnect loop.

#### 2. UI Updates (`src/components/LiveStream.tsx`)
- **"Reconnecting..." Status Pill**: Added an `isReconnecting` state. When the connection drops, the status pill turns into a yellow, pulsating `Reconnecting...` indicator instead of just sitting in a broken state.
- **Success Notification**: Added a toast notification using `sonner` that says `"Connection successfully restored"` as soon as the client recovers the connection, so the user knows everything is back to normal.

---

### 🧪 How I Tested It:
1. Ran the frontend and Go backend locally.
2. Started a live log stream in the dashboard.
3. Manually stopped the backend server in my terminal. The status pill switched to `Reconnecting...` instantly and backed off correctly (retrying at 2s, 4s, 8s intervals).
4. Restarted the backend server. The stream client successfully reconnected, resumed the logs, and showed a beautiful "Connection successfully restored" toast notification without needing a page refresh!

Let me know if there's anything else you'd like me to tweak! Thanks for assigning me this issue! 😄


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unwanted reconnects after manual disconnect and improved stability during connection transitions

* **New Features**
  * Added a visible "Reconnecting..." status with attempt count and distinct indicator styling
  * Streaming controls remain active during reconnect so streams stay responsive

* **UX Improvements**
  * Hover behavior refined so the log row copy button appears reliably when hovering a log entry

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sarika-03/LogPulse/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->