### PR TITLE
cleanup: remove dead log-level detection loop from agent

### DIFF
--- a/backend/cmd/agent/main.go
+++ b/backend/cmd/agent/main.go
@@ -269,13 +269,6 @@ func (a *Agent) tailFile(path string, baseLabels map[string]string) {
 		}
 		labels["filename"] = filepath.Base(path)
 
-		// Auto-detect log level from content
-		for i := range entries {
-			_ = detectLogLevel(entries[i].Line)
-			// Store level in a temporary way - we'll add it to labels per entry
-			entries[i].Line = entries[i].Line // Keep original
-		}
-
 		// For simplicity, add level to labels based on most common level in batch
 		// In production, you'd want per-entry labels
 		labels["level"] = detectLogLevel(entries[0].Line)


### PR DESCRIPTION
# Cleanup: Remove Dead Log-Level Detection Loop from Agent

This PR removes an unused log level detection loop and associated no-op self-assignments from the Go log ingestion agent inside `backend/cmd/agent/main.go`. All checks and tests run cleanly.

## 🐛 Problem
Inside the Go agent's `tailFile` function, a loop was running for every log batch to auto-detect the log level for each entry:
```go
// Auto-detect log level from content
for i := range entries {
    _ = detectLogLevel(entries[i].Line)
    // Store level in a temporary way - we'll add it to labels per entry
    entries[i].Line = entries[i].Line // Keep original
}
