### PR TITLE
fix(backend): properly handle http.NewRequest error to prevent panic

### DIFF
--- a/backend/internal/plugin/webhook.go
+++ b/backend/internal/plugin/webhook.go
@@ -32,7 +32,11 @@ func (w *WebhookNotifier) Notify(event string, payload map[string]interface{}) {
 		}
 		go func(url string) {
 			b, _ := json.Marshal(payload)
-			req, _ := http.NewRequest("POST", url, bytes.NewBuffer(b))
+			req, err := http.NewRequest("POST", url, bytes.NewBuffer(b))
+			if err != nil {
+				log.Printf("Webhook request creation error: %v", err)
+				return
+			}
 			req.Header.Set("Content-Type", "application/json")
 			client := &http.Client{Timeout: 5 * time.Second}
 			resp, err := client.Do(req)


### PR DESCRIPTION
﻿## What changed
* Added proper error handling for http.NewRequest in ackend/internal/plugin/webhook.go.
* Replaced eq, _ := with eq, err := and added an if err != nil check.

## Why
Previously, if http.NewRequest failed (e.g., due to an invalid webhook URL), eq was returned as 
il. The subsequent call to eq.Header.Set() caused a nil-pointer dereference panic. Because this code runs in an unrecovered goroutine, it caused the entire Go application to crash (Denial of Service). Properly catching and logging the error prevents this crash.

## How to test
Run the Go tests or manually trigger a webhook with a malformed URL.
`ash id="t1x9ab"
go test ./...
`
Expected result:
* The backend does not crash and correctly logs the request creation error.

## Screenshots (if UI change)
N/A 

## Related issue
Closes #41

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook notification error handling - webhook request creation failures are now properly logged and those webhooks are skipped accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sarika-03/LogPulse/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->