### PR TITLE
fix(frontend): wrap localStorage in try/catch to prevent crashes

### DIFF
--- a/src/components/SavedSearches.tsx
+++ b/src/components/SavedSearches.tsx
@@ -41,7 +41,11 @@ export function SavedSearches({ onExecuteSearch, currentQuery, currentTimeRange 
   }, []);
 
   const saveToStorage = (newSearches: SavedSearch[]) => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(newSearches));
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newSearches));
+    } catch {
+      // Fail silently for quota or privacy mode errors
+    }
     setSearches(newSearches);
   };
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,22 +5,34 @@ class ApiClient {
 
   setConfig(config: BackendConfig) {
     this.config = config;
-    localStorage.setItem('logpulse_config', JSON.stringify(config));
+    try {
+      localStorage.setItem('logpulse_config', JSON.stringify(config));
+    } catch {
+      // Fail silently for quota or privacy mode errors
+    }
   }
 
   getConfig(): BackendConfig | null {
     if (this.config) return this.config;
-    const stored = localStorage.getItem('logpulse_config');
-    if (stored) {
-      this.config = JSON.parse(stored);
-      return this.config;
+    try {
+      const stored = localStorage.getItem('logpulse_config');
+      if (stored) {
+        this.config = JSON.parse(stored);
+        return this.config;
+      }
+    } catch {
+      // Fail silently if parsing fails or storage is inaccessible
     }
     return null;
   }
 
   clearConfig() {
     this.config = null;
-    localStorage.removeItem('logpulse_config');
+    try {
+      localStorage.removeItem('logpulse_config');
+    } catch {
+      // Fail silently
+    }
   }
 
   private getHeaders(): HeadersInit {


### PR DESCRIPTION
﻿## What changed
* Added 	ry/catch wrappers around all localStorage.setItem, localStorage.getItem, and localStorage.removeItem calls in src/lib/api.ts and src/components/SavedSearches.tsx.
* Added 	ry/catch protection around JSON.parse() for stored configurations to prevent syntax errors on corrupted data.

## Why
Calling the Web Storage API synchronously without error handling can throw synchronous exceptions (e.g., SecurityError, QuotaExceededError) in strict privacy modes (like Safari Private). Uncaught exceptions during React renders or module initialization cause the entire component tree to unmount, resulting in a blank white screen. This fix ensures that storage failures degrade gracefully without crashing the application.

## How to test
Run the frontend:
`ash id="t1x9ab"
npm run dev
`
Expected result:
* The frontend works normally. If you block cookies/storage via browser settings, the app still renders and operates normally instead of instantly throwing an uncaught exception.

## Screenshots (if UI change)
N/A 

## Related issue
Closes #43

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
