### PR TITLE
docs: add Table of Contents and Contributors section with contrib.rocks badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# TOC TEST 999999
 # LogPulse Frontend
 
 Modern React-based web interface for LogPulse log aggregation system.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
+# TOC TEST 999999
 # LogPulse Frontend
 
 Modern React-based web interface for LogPulse log aggregation system.
+
+## 📚 Table of Contents
+
+- [🚀 Features](#-features)
+- [📋 Prerequisites](#-prerequisites)
+- [🛠️ Installation](#-installation)
+- [🔧 Configuration](#-configuration)
+- [📖 Usage](#-usage)
+- [🏗️ Project Structure](#-project-structure)
+- [🎨 Customization](#-customization)
+- [🚢 Production Build](#-production-build)
+- [🐛 Troubleshooting](#-troubleshooting)
+- [📝 Development Tips](#-development-tips)
+- [🤝 Contributing](#-contributing)
+- [👥 Contributors](#-contributors)
+- [📄 License](#-license)
+- [🙏 Acknowledgments](#-acknowledgments)
 
 ## 🚀 Features
 
@@ -318,6 +336,7 @@ Thanks to all contributors ❤️
 
 [![Contributors](https://contrib.rocks/image?repo=sarika-03/LogPulse)](https://github.com/sarika-03/LogPulse/graphs/contributors)
 
+<!-- toc update fix -->
 ---
 
 **Need help?** Check the [main README](../README.md) or open an issue on GitHub.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ MIT License - see LICENSE file
 - Icons from Lucide React
 - Inspired by Grafana and Kibana
 
+## 👥 Contributors
+
+Thanks to all contributors ❤️
+
+[![Contributors](https://contrib.rocks/image?repo=sarika-03/LogPulse)](https://github.com/sarika-03/LogPulse/graphs/contributors)
+
 ---
 
 **Need help?** Check the [main README](../README.md) or open an issue on GitHub.


### PR DESCRIPTION
Current Problem:
The README.md currently lacks a proper Contributors section to recognize contributors and guide new ones. Additionally, contributor visibility is not visually enhanced, and the Table of Contents did not reflect this section earlier.

Proposed Solution:
Add a Contributors section at the end of the README
Include an auto-generated contrib.rocks badge to visually display contributors
Update the Table of Contents to include the Contributors section
Maintain all existing content without removing or breaking anything
Improve overall formatting and readability of the README

Benefits:
Recognizes and credits contributors visually
Makes the repository more welcoming for new contributors
Improves documentation structure and navigation
Enhances README UI/UX with contributor avatars
Encourages open-source participation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Table of Contents to README with links to key sections.
  * Introduced Contributors section with dynamic contributors badge.


closes #22 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->